### PR TITLE
快速执行 bb-translator.exe --disable-git的bat

### DIFF
--- a/skip_git.bat
+++ b/skip_git.bat
@@ -1,0 +1,3 @@
+@echo off
+start "" "bb-translator.exe" --disable-git
+exit


### PR DESCRIPTION
如题，快速对bat所在同级目录执行bb-translator.exe --disable-git的bat，减少时间浪费